### PR TITLE
use dictionary.get instead of getattr for clock_speed

### DIFF
--- a/adafruit_avrprog.py
+++ b/adafruit_avrprog.py
@@ -127,7 +127,7 @@ class AVRprog:
             print("Erasing chip....")
         self.erase_chip()
 
-        clock_speed = getattr(chip, "clock_speed", _FAST_CLOCK)
+        clock_speed = chip.get("clock_speed", _FAST_CLOCK)
         self.begin(clock=clock_speed)
 
         # create a file state dictionary
@@ -196,7 +196,7 @@ class AVRprog:
             "f"
         ]:
             page_size = chip["page_size"]
-            clock_speed = getattr(chip, "clock_speed", _FAST_CLOCK)
+            clock_speed = chip.get("clock_speed", _FAST_CLOCK)
             self.begin(clock=clock_speed)
             for page_addr in range(0x0, chip["flash_size"], page_size):
                 page_buffer = bytearray(page_size)


### PR DESCRIPTION
this contains the same changes as #25 

I'm trying to look into why the actions check did not pass on that PR and github no longer shows the output. So I've made this PR to try to get it to run again so I can see the output.

If the original contributing user restores the branch from that PR it can be reviewed / merged instead of this one.