### PR TITLE
changed getattr() calls to chip.get() to correct clock_speed override code

### DIFF
--- a/adafruit_avrprog.py
+++ b/adafruit_avrprog.py
@@ -127,7 +127,7 @@ class AVRprog:
             print("Erasing chip....")
         self.erase_chip()
 
-        clock_speed = getattr(chip, "clock_speed", _FAST_CLOCK)
+        clock_speed = chip.get("clock_speed", _FAST_CLOCK)
         self.begin(clock=clock_speed)
 
         # create a file state dictionary
@@ -196,7 +196,7 @@ class AVRprog:
             "f"
         ]:
             page_size = chip["page_size"]
-            clock_speed = getattr(chip, "clock_speed", _FAST_CLOCK)
+            clock_speed = chip.get("clock_speed", _FAST_CLOCK)
             self.begin(clock=clock_speed)
             for page_addr in range(0x0, chip["flash_size"], page_size):
                 page_buffer = bytearray(page_size)


### PR DESCRIPTION
The code to override the default clock_speed was incorrectly looking for an attribute instead of a key/value pair.
