### PR TITLE
Add support for ATmega328PB

### DIFF
--- a/adafruit_avrprog.py
+++ b/adafruit_avrprog.py
@@ -71,6 +71,13 @@ class AVRprog:
             "page_size": 128,
             "fuse_mask": (0xFF, 0xFF, 0x07, 0x3F),
         }
+        ATmega328pb = {
+            "name": "ATmega328pb",
+            "sig": [0x1E, 0x95, 0x16],
+            "flash_size": 32768,
+            "page_size": 128,
+            "fuse_mask": (0xFF, 0xFF, 0x07, 0x3F),
+        }
         ATmega644pa = {
             "name": "ATmega644pa",
             "sig": [0x1E, 0x96, 0x0A],


### PR DESCRIPTION
This pull request adds support for ATmega328PB.

ATmega328PB contains some new features and improvements. It is software-compatible with the ATmega328P.

https://onlinedocs.microchip.com/pr/GUID-CBDC1838-0100-4F26-A45A-134958193C3B-en-US-4/index.html

Tested on an Arduino Nano clone using a VCC-GND YD-RP2040.